### PR TITLE
Fix event path from pyinotify

### DIFF
--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -5,6 +5,7 @@ import pyinotify
 
 from operator import attrgetter
 
+import os
 
 class Stream(object):
 
@@ -48,7 +49,7 @@ class Stream(object):
             except KeyError:
                 print 'Ignoring event with opflag {}'.format(event.mask)
             else:
-                self.final_callback(event_class(event.name))
+                self.final_callback(event_class(os.path.join(event.path, event.name)))
 
 
 class Observer(object):


### PR DESCRIPTION
event.name only has the name of the file. If it is not joined with event.path, pytex does detect changes in build directory and rebuilds infinitely the project. 
