### PR TITLE
Patch vim tmp

### DIFF
--- a/pytex/commands/building.py
+++ b/pytex/commands/building.py
@@ -236,6 +236,10 @@ class Watch(Compile):
                 self.logger.debug('Ignoring GIT action')
                 return
 
+            if relative == '4913':
+                self.logger.debug('Ignoring vim temp file')
+                return
+
             if event.path.startswith(tempdir):
                 self.logger.debug('Ignoring {!r}'.format(relative))
                 return


### PR DESCRIPTION
Vim always tries to create file 4913 to see if it can create new file. This should not trigger a new compilation. 
