### PR TITLE
Add atomic_save mode for watch command

### DIFF
--- a/pytex/commands/building.py
+++ b/pytex/commands/building.py
@@ -305,7 +305,7 @@ class Watch(Compile):
         self.logger.info('Watching {} for changes...'.format(base))
 
         observer = monitor.Observer()
-        observer.monitor(os.path.realpath('.'), handler)
+        observer.monitor(os.path.realpath('.'), handler, self.config)
         observer.start()
 
         try:

--- a/pytex/default-settings.ini
+++ b/pytex/default-settings.ini
@@ -15,3 +15,6 @@ nomenclature=makeindex -s nomencl.ist -q
 
 [spellcheck]
 command=hunspell -t -i utf-8
+
+[watch]
+atomic_save=false

--- a/pytex/monitors/fsevents.py
+++ b/pytex/monitors/fsevents.py
@@ -41,7 +41,7 @@ class Stream(fsevents.Stream):
 
 class Observer(fsevents.Observer):
 
-    def monitor(self, path, callback):
+    def monitor(self, path, callback, config):
         stream = Stream(callback, path)
         super(Observer, self).schedule(stream)
 

--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -11,15 +11,14 @@ class Stream(object):
     EVENT_MAPPINGS = {
 # TODO: The following OP flags are not yet defined. Do we need them?
 #       pyinotify.IN_ACCESS        : 0x00000001,  # File was accessed
-#       pyinotify.IN_CLOSE_WRITE   : 0x00000008,  # Writable file was closed
 #       pyinotify.IN_CLOSE_NOWRITE : 0x00000010,  # Unwritable file closed
 #       pyinotify.IN_OPEN          : 0x00000020,  # File was opened
 #       pyinotify.IN_DELETE_SELF   : 0x00000400,  # Self (watched item itself) was deleted
 #       pyinotify.IN_MOVE_SELF     : 0x00000800,  # Self (watched item itself) was moved
-        pyinotify.IN_ATTRIB: base.FileModified,
         pyinotify.IN_CREATE: base.FileCreated,
         pyinotify.IN_MODIFY: base.FileModified,
         pyinotify.IN_DELETE: base.FileDeleted,
+        pyinotify.IN_CLOSE_WRITE: base.FileModified,
         (pyinotify.IN_MOVED_FROM, pyinotify.IN_MOVED_TO): base.FileMoved,
     }
 
@@ -60,12 +59,17 @@ class Observer(object):
     def start(self):
         self.notifier.start()
 
-    def monitor(self, path, callback):
+    def monitor(self, path, callback, config):
         stream = Stream(callback)
         mask = 0
-        mask |= pyinotify.IN_CREATE | pyinotify.IN_MODIFY | pyinotify.IN_DELETE
+
+        if config.get('watch', 'atomic_save') == 'true':
+            mask |= pyinotify.IN_CLOSE_WRITE
+        else:
+            mask |= pyinotify.IN_CREATE | pyinotify.IN_MODIFY | pyinotify.IN_DELETE
+
         mask |= pyinotify.IN_MOVED_FROM | pyinotify.IN_MOVED_TO
-        mask |= pyinotify.IN_ATTRIB
+
         self.vm.add_watch(path, mask, stream.handle_event, rec=True)
 
     def stop(self):


### PR DESCRIPTION
This mode can be useful for Vim users with _writebackup_ option.
When the watch.atomic_save option is set in the config, only
_CLOSE_WRITE_ event are watched. This option should only be used
with care since new files and deletion of files will not correctly
be handled.
