### PR TITLE
Coalescing events from pyinotify 

### DIFF
--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -22,7 +22,7 @@ class Observer(threading.Thread):
     def __init__(self):
         super(Observer, self).__init__()
         self.vm = pyinotify.WatchManager()
-        self.notifier = pyinotify.Notifier(self.vm, timeout=100)
+        self.notifier = pyinotify.Notifier(self.vm, timeout=10)
         self.stop_requested = False
 
     def monitor(self, path, callback):

--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -20,10 +20,10 @@ class CoalescerThread(threading.Thread):
     }
 
     def __init__(self):
-        threading.Thread.__init__(self)
+        super(CoalescerThread, self).__init__()
         self.vm = pyinotify.WatchManager()
         self.notifier = pyinotify.Notifier(self.vm, timeout=100)
-        self.flag = False
+        self.stop_requested = False
 
     def monitor(self, path, callback):
         self.final_callback = callback
@@ -36,7 +36,7 @@ class CoalescerThread(threading.Thread):
         self.vm.add_watch(path, mask, self.handle_event, rec=True)
 
     def run(self):
-        while not self.flag:
+        while not self.stop_requested:
             # Process events
             self.notifier.process_events()
             while self.notifier.check_events():
@@ -69,13 +69,13 @@ class CoalescerThread(threading.Thread):
             try:
                 event_class = self.EVENT_MAPPINGS[event.mask]
             except KeyError:
-                print 'Ignoring event with opflag {}'.format(event.mask)
+                print 'Ignoring event with opstop_requested {}'.format(event.mask)
             else:
                 path = os.path.join(event.path, event.name)
                 self.event_buffer[path] += [event_class(path)]
 
     def stop(self):
-        self.flag = True
+        self.stop_requested = True
         self.join()
 
 

--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import
 from pytex.monitors import base
 import pyinotify
 
+from operator import attrgetter
+
 import os
 import threading
 from collections import defaultdict
 
-class CoalescerThread (threading.Thread):
+
+class CoalescerThread(threading.Thread):
     EVENT_MAPPINGS = {
         pyinotify.IN_ATTRIB: base.FileModified,
         pyinotify.IN_CREATE: base.FileCreated,
@@ -41,7 +44,7 @@ class CoalescerThread (threading.Thread):
                 self.notifier.process_events()
 
             # Send callbacks for the last item of each event
-            for k,v in self.event_buffer.iteritems():
+            for k, v in self.event_buffer.iteritems():
                 self.final_callback(v[-1])
 
             self.event_buffer.clear()
@@ -68,11 +71,13 @@ class CoalescerThread (threading.Thread):
             except KeyError:
                 print 'Ignoring event with opflag {}'.format(event.mask)
             else:
-                self.event_buffer[os.path.join(event.path, event.name)] += [event_class(os.path.join(event.path, event.name))]
+                path = os.path.join(event.path, event.name)
+                self.event_buffer[path] += [event_class(path)]
 
     def stop(self):
         self.flag = True
         self.join()
+
 
 class Observer(object):
     def __init__(self):

--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -10,7 +10,7 @@ import threading
 from collections import defaultdict
 
 
-class CoalescerThread(threading.Thread):
+class Observer(threading.Thread):
     EVENT_MAPPINGS = {
         pyinotify.IN_ATTRIB: base.FileModified,
         pyinotify.IN_CREATE: base.FileCreated,
@@ -20,7 +20,7 @@ class CoalescerThread(threading.Thread):
     }
 
     def __init__(self):
-        super(CoalescerThread, self).__init__()
+        super(Observer, self).__init__()
         self.vm = pyinotify.WatchManager()
         self.notifier = pyinotify.Notifier(self.vm, timeout=100)
         self.stop_requested = False
@@ -69,7 +69,7 @@ class CoalescerThread(threading.Thread):
             try:
                 event_class = self.EVENT_MAPPINGS[event.mask]
             except KeyError:
-                print 'Ignoring event with opstop_requested {}'.format(event.mask)
+                print 'Ignoring event with opflag {}'.format(event.mask)
             else:
                 path = os.path.join(event.path, event.name)
                 self.event_buffer[path] += [event_class(path)]
@@ -77,17 +77,3 @@ class CoalescerThread(threading.Thread):
     def stop(self):
         self.stop_requested = True
         self.join()
-
-
-class Observer(object):
-    def __init__(self):
-        self.coalescer = CoalescerThread()
-
-    def start(self):
-        self.coalescer.start()
-
-    def monitor(self, path, callback):
-        self.coalescer.monitor(path, callback)
-
-    def stop(self):
-        self.coalescer.stop()

--- a/pytex/monitors/pyinotify.py
+++ b/pytex/monitors/pyinotify.py
@@ -3,20 +3,12 @@ from __future__ import absolute_import
 from pytex.monitors import base
 import pyinotify
 
-from operator import attrgetter
-
 import os
+import threading
+from collections import defaultdict
 
-class Stream(object):
-
+class CoalescerThread (threading.Thread):
     EVENT_MAPPINGS = {
-# TODO: The following OP flags are not yet defined. Do we need them?
-#       pyinotify.IN_ACCESS        : 0x00000001,  # File was accessed
-#       pyinotify.IN_CLOSE_WRITE   : 0x00000008,  # Writable file was closed
-#       pyinotify.IN_CLOSE_NOWRITE : 0x00000010,  # Unwritable file closed
-#       pyinotify.IN_OPEN          : 0x00000020,  # File was opened
-#       pyinotify.IN_DELETE_SELF   : 0x00000400,  # Self (watched item itself) was deleted
-#       pyinotify.IN_MOVE_SELF     : 0x00000800,  # Self (watched item itself) was moved
         pyinotify.IN_ATTRIB: base.FileModified,
         pyinotify.IN_CREATE: base.FileCreated,
         pyinotify.IN_MODIFY: base.FileModified,
@@ -24,9 +16,35 @@ class Stream(object):
         (pyinotify.IN_MOVED_FROM, pyinotify.IN_MOVED_TO): base.FileMoved,
     }
 
-    def __init__(self, callback):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.vm = pyinotify.WatchManager()
+        self.notifier = pyinotify.Notifier(self.vm, timeout=100)
+        self.flag = False
+
+    def monitor(self, path, callback):
         self.final_callback = callback
         self.linked_events = {}
+        self.event_buffer = defaultdict(list)
+        mask = 0
+        mask |= pyinotify.IN_CREATE | pyinotify.IN_MODIFY | pyinotify.IN_DELETE
+        mask |= pyinotify.IN_MOVED_FROM | pyinotify.IN_MOVED_TO
+        mask |= pyinotify.IN_ATTRIB
+        self.vm.add_watch(path, mask, self.handle_event, rec=True)
+
+    def run(self):
+        while not self.flag:
+            # Process events
+            self.notifier.process_events()
+            while self.notifier.check_events():
+                self.notifier.read_events()
+                self.notifier.process_events()
+
+            # Send callbacks for the last item of each event
+            for k,v in self.event_buffer.iteritems():
+                self.final_callback(v[-1])
+
+            self.event_buffer.clear()
 
     def handle_event(self, event):
         if hasattr(event, 'cookie'):
@@ -41,7 +59,8 @@ class Stream(object):
                 events.sort(key=attrgetter('mask'))
                 events = [(e.mask, e.path) for e in events]
                 key, paths = zip(*events)
-                self.final_callback(self.EVENT_MAPPINGS[key](*paths))
+                for e in self.EVENT_MAPPINGS[key](*paths):
+                    self.event_buffer[e.path] += [e]
         else:
             # Handle single event
             try:
@@ -49,25 +68,21 @@ class Stream(object):
             except KeyError:
                 print 'Ignoring event with opflag {}'.format(event.mask)
             else:
-                self.final_callback(event_class(os.path.join(event.path, event.name)))
-
-
-class Observer(object):
-
-    def __init__(self):
-        self.vm = pyinotify.WatchManager()
-        self.notifier = pyinotify.ThreadedNotifier(self.vm)
-
-    def start(self):
-        self.notifier.start()
-
-    def monitor(self, path, callback):
-        stream = Stream(callback)
-        mask = 0
-        mask |= pyinotify.IN_CREATE | pyinotify.IN_MODIFY | pyinotify.IN_DELETE
-        mask |= pyinotify.IN_MOVED_FROM | pyinotify.IN_MOVED_TO
-        mask |= pyinotify.IN_ATTRIB
-        self.vm.add_watch(path, mask, stream.handle_event, rec=True)
+                self.event_buffer[os.path.join(event.path, event.name)] += [event_class(os.path.join(event.path, event.name))]
 
     def stop(self):
-        self.notifier.stop()
+        self.flag = True
+        self.join()
+
+class Observer(object):
+    def __init__(self):
+        self.coalescer = CoalescerThread()
+
+    def start(self):
+        self.coalescer.start()
+
+    def monitor(self, path, callback):
+        self.coalescer.monitor(path, callback)
+
+    def stop(self):
+        self.coalescer.stop()


### PR DESCRIPTION
- Use a Notifier instead of ThreadedNotifier
- Use a timeout of 100ms
- On timeout, keep only the last event for each file
- Use defaultdict for future extensibility, so that more advanced coalescing policies could be used in the future
