### PR TITLE
Bib aux name

### DIFF
--- a/pytex/commands/building.py
+++ b/pytex/commands/building.py
@@ -171,9 +171,8 @@ class Compile(Command):
         base = os.path.realpath('.')
 
         cmd = shlex.split(self.config.get('compilation', 'bibliography'))
-        cmd += [
-            '{}'.format(master),
-        ]
+        cmd += [master]
+
         self.logger.debug(' '.join(cmd))
 
         try:

--- a/pytex/commands/building.py
+++ b/pytex/commands/building.py
@@ -172,7 +172,7 @@ class Compile(Command):
 
         cmd = shlex.split(self.config.get('compilation', 'bibliography'))
         cmd += [
-            '{}.aux'.format(master),
+            '{}'.format(master),
         ]
         self.logger.debug(' '.join(cmd))
 


### PR DESCRIPTION
This PR adds support for building the bibliography with biber

Only pass master to the bibliography command:
- .aux is automatically added to bibtex: bibtex master works
- .aux is not supported by biber: _only_ biber master works
