### PR TITLE
PEP8 Compliance

### DIFF
--- a/pytex/commands/diff.py
+++ b/pytex/commands/diff.py
@@ -9,7 +9,8 @@ from pytex.commands import building
 class Compare(Command):
 
     name = 'diff'
-    help = 'Creates a PDF document highligthing the changes between two tags in the repository.'
+    help = 'Creates a PDF document highlighting the changes'\
+           'between two tags in the repository.'
 
     def parser(self):
         parser = self.parser_class()
@@ -55,7 +56,7 @@ class Compare(Command):
         if os.path.exists(diff_dir):
             shutil.rmtree(diff_dir)
         shutil.copytree(to_dir, diff_dir,
-                ignore=shutil.ignore_patterns('*.tex'))
+                        ignore=shutil.ignore_patterns('*.tex'))
 
         # TODO: Is it correct to simply ignore files present in
         # the older version which aren't anymore in the new one?
@@ -97,7 +98,8 @@ class Compare(Command):
                         fh.write(out)
 
         # Build the resulting document
-        dest = os.path.join(base, '{}-diff-{}-{}.pdf'.format(name, args.from_ref, args.to_ref))
+        dest = os.path.join(base, '{}-diff-{}-{}.pdf'
+                                  .format(name, args.from_ref, args.to_ref))
         self.compile(diff_dir, dest)
 
 

--- a/pytex/commands/spellcheck.py
+++ b/pytex/commands/spellcheck.py
@@ -10,7 +10,7 @@ from pytex.subcommands import Command
 class Spellcheck(Command):
 
     name = 'spellcheck', 'sp'
-    help = 'Checks every LaTeX source file in the document for spelling errors.'
+    help = 'Spell checks each LaTeX source file in the document.'
 
     def execute(self, args):
         base = os.path.realpath('.')
@@ -27,7 +27,6 @@ class Spellcheck(Command):
                 break
         else:
             self.logger.info('Done')
-
 
     def spellcheck_file(self, file):
         base = os.path.realpath('.')

--- a/pytex/commands/templates.py
+++ b/pytex/commands/templates.py
@@ -29,7 +29,7 @@ class Update(Command):
 
     name = 'update-templates'
     help = 'Updates the current templates set by pulling '\
-            'the latest changes from the remote git repository.'
+           'the latest changes from the remote git repository.'
 
     def execute(self, args):
         raise NotImplementedError()

--- a/pytex/commands/typesetting.py
+++ b/pytex/commands/typesetting.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import curses
 
 from pytex.subcommands import Command
@@ -10,7 +9,9 @@ from pytex.utils import find_files_of_type
 class FindUnreferencedAcronyms(Command):
 
     name = 'checkacronyms', 'ca'
-    acronym_regex = r'[^a-zA-Z_\\-]((?:[A-Z]+[a-z-][A-Z]+|[A-Z]{2,})[a-z0-9]{0,3})[^a-zA-Z0-9_\\-]'
+    acronym_regex = r'[^a-zA-Z_\\-]'\
+                    r'((?:[A-Z]+[a-z-][A-Z]+|[A-Z]{2,})[a-z0-9]{0,3})'\
+                    r'[^a-zA-Z0-9_\\-]'
 
     def parser(self):
         parser = self.parser_class()
@@ -33,7 +34,6 @@ class FindUnreferencedAcronyms(Command):
                     line = line.strip()
                     if line:
                         ignored.add(line)
-
 
         stdscr = curses.initscr()
         curses.savetty()
@@ -74,7 +74,6 @@ class FindUnreferencedAcronyms(Command):
                         ce = contents.find(" ", ce)
                         postfix = '...'
 
-
                     char = ms - cs
 
                     ms -= cs
@@ -82,7 +81,8 @@ class FindUnreferencedAcronyms(Command):
 
                     token = token[cs:ce]
 
-                    self.print_token_color(stdscr, f, token, line, char, ms, me, prefix, postfix)
+                    self.print_token_color(stdscr, f, token, line, char,
+                                           ms, me, prefix, postfix)
 
                     callbacks = {
                         'l': self.replace_lower,
@@ -115,7 +115,6 @@ class FindUnreferencedAcronyms(Command):
                 with open(f, 'w') as fh:
                     fh.write(contents)
 
-
     def replace_lower(self, content, start, end):
         self.replacements.append((
             start, end,
@@ -128,7 +127,6 @@ class FindUnreferencedAcronyms(Command):
             '\\Gls{{{}}}'.format(content[start:end].lower())
         ))
 
-
     def replace_lower_plural(self, content, start, end):
         name = content[start:end]
         if name.endswith('s'):
@@ -137,7 +135,6 @@ class FindUnreferencedAcronyms(Command):
             start, end,
             '\\glspl{{{}}}'.format(name.lower())
         ))
-
 
     def replace_upper_plural(self, content, start, end):
         name = content[start:end]
@@ -148,14 +145,15 @@ class FindUnreferencedAcronyms(Command):
             '\\Glspl{{{}}}'.format(name.lower())
         ))
 
-
-    def print_token_color(self, stdscr, path, token, line, char, start, end, prefix, postfix):
-        path_prefix = ':{}:{}-{}'.format(line + 1, char + 1, char + end - start)
+    def print_token_color(self, stdscr, path, token, line, char, start, end,
+                          prefix, postfix):
         abbr = token[start:end]
+        path_prefix = ':{}:{}-{}'.format(line + 1, char + 1,
+                                         char + end - start)
 
         stdscr.erase()
         stdscr.addstr(1, 5, path+path_prefix)
-        path_prefix=''
+        path_prefix = ''
 
         chunksize = 80
         line = 0
@@ -166,13 +164,13 @@ class FindUnreferencedAcronyms(Command):
             if start > chunksize:
                 start -= chunksize
             elif start is not None:
-                stdscr.addstr(3 + line, 5 + start + len(prefix), abbr, curses.A_UNDERLINE | curses.A_BOLD)
+                stdscr.addstr(3 + line, 5 + start + len(prefix), abbr,
+                              curses.A_UNDERLINE | curses.A_BOLD)
                 start = None
 
             line += 1
 
         stdscr.refresh()
-
 
     def print_token_plain(self, stdscr, token, line, char, start, end):
         prefix = '{}:{}-{} - '.format(line + 1, char + 1, char + end - start)

--- a/pytex/commands/versioning.py
+++ b/pytex/commands/versioning.py
@@ -14,9 +14,9 @@ class Versions(Command):
         parser = self.parser_class()
         parser.add_argument('-c', '--current')
         parser.add_argument('-l', '--latex', action='store_const',
-                const=True, default=False)
+                            const=True, default=False)
         parser.add_argument('-f', '--format',
-                default='{0.name} - {0.tagger[0]} | "{0.message}"')
+                            default='{0.name} - {0.tagger[0]} | "{0.message}"')
         return parser
 
     def execute(self, args):
@@ -66,7 +66,8 @@ saving_command = Save()
 class Tag(Command):
 
     name = 'tag'
-    help = 'Creates a tagged version of the document out of the currently active commit.'
+    help = 'Creates a tagged version of the document'\
+           'out of the currently active commit.'
 
     def parser(self):
         parser = self.parser_class()

--- a/pytex/logging.py
+++ b/pytex/logging.py
@@ -45,7 +45,7 @@ class LevelColoringFormatter(logging.Formatter):
 
         color = LevelColoringFormatter.LEVELS_TO_COLORS[level]
         return s.replace(record.levelname,
-                hilite(record.levelname, color=color), 1)
+                         hilite(record.levelname, color=color), 1)
 
 
 class StdioOnnaStick(object):
@@ -99,12 +99,13 @@ class LoggingSubsystem(object):
 
     def start(self):
         # Configure logging
-        file_formatter = logging.Formatter("%(asctime)s - %(levelname)s - " \
-                "%(name)s - %(message)s (%(pathname)s:%(lineno)d)")
+        file_formatter = logging.Formatter("%(asctime)s - %(levelname)s - "
+                                           "%(name)s - %(message)s "
+                                           "(%(pathname)s:%(lineno)d)")
 
         if sys.__stdout__.isatty():
-            console_formatter = LevelColoringFormatter("%(levelname)10s: " \
-                    "%(message)s")
+            console_formatter = LevelColoringFormatter("%(levelname)10s: "
+                                                       "%(message)s")
         else:
             console_formatter = logging.Formatter("%(message)s")
 
@@ -150,5 +151,5 @@ class LoggingSubsystem(object):
             self.buffered_handler.close()
 
             print >>sys.__stdout__, "pytex exited with a non-zero exit " \
-                    "status (%d). A complete log was stored in the %s " \
-                    "file." % (status, self.logfile)
+                "status (%d). A complete log was stored in the %s " \
+                "file." % (status, self.logfile)

--- a/pytex/monitors/base.py
+++ b/pytex/monitors/base.py
@@ -21,6 +21,7 @@ class FileDeleted(FSEvent):
 class AttributeChanged(FSEvent):
     pass
 
+
 class FileMoved(FSEvent):
 
     def __init__(self, src, dst):
@@ -29,7 +30,7 @@ class FileMoved(FSEvent):
 
     def __repr__(self):
         return '{}({} -> {})'.format(
-                self.__class__.__name__, self.src, self.dst)
+            self.__class__.__name__, self.src, self.dst)
 
 
 class FileCopied(FSEvent):

--- a/pytex/scripts/pytex.py
+++ b/pytex/scripts/pytex.py
@@ -14,10 +14,10 @@ def build_parser():
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + pytex.VERSION)
     parser.add_argument('-v', '--verbose', default=list(),
-                        action='append_const', const=1, help='Increments the' \
+                        action='append_const', const=1, help='Increments the'
                         ' verbosity (can be used multiple times).')
     parser.add_argument('-q', '--quiet', default=list(),
-                        action='append_const', const=1, help='Decrements the' \
+                        action='append_const', const=1, help='Decrements the'
                         ' verbosity (can be used multiple times).')
 
     commands = subcommands.load('pytex.commands')

--- a/pytex/subcommands.py
+++ b/pytex/subcommands.py
@@ -23,7 +23,8 @@ class Command(object):
         names = getattr(self, 'name', None)
 
         if not names:
-            raise ValueError('No name defined for command {}'.format(self.__class__.__name__))
+            raise ValueError('No name defined for command {}'
+                             .format(self.__class__.__name__))
 
         if not isinstance(names, basestring):
             names = names[0]
@@ -34,7 +35,8 @@ class Command(object):
         names = getattr(self, 'name', None)
 
         if not names:
-            raise ValueError('No name defined for command {}'.format(self.__class__.__name__))
+            raise ValueError('No name defined for command {}'
+                             .format(self.__class__.__name__))
 
         if isinstance(names, basestring):
             names = [names]

--- a/pytex/utils.py
+++ b/pytex/utils.py
@@ -8,7 +8,8 @@ def is_sublist(sublist, superlist):
     return False
 
 
-def find_files_of_type(basedir, extensions, exclude_dirs=None, exclude_files=None):
+def find_files_of_type(basedir, extensions, exclude_dirs=None,
+                       exclude_files=None):
     matches = set()
 
     if isinstance(extensions, basestring):

--- a/pytex/versioning/git.py
+++ b/pytex/versioning/git.py
@@ -38,11 +38,13 @@ class Tag(object):
         self._tagger = self._parse_tagger(details)
 
     def _parse_date(self, details):
-        match = re.search('^Date:\s+(?P<date>.*)$', details, flags=re.MULTILINE)
+        match = re.search('^Date:\s+(?P<date>.*)$',
+                          details, flags=re.MULTILINE)
         return dparser.parse(match.group('date'))
 
     def _parse_tagger(self, details):
-        match = re.search('^Tagger: (?P<tagger>[^<]+) <(?P<email>[^>]+)>$', details, flags=re.MULTILINE)
+        match = re.search('^Tagger: (?P<tagger>[^<]+) <(?P<email>[^>]+)>$',
+                          details, flags=re.MULTILINE)
         return match.group('tagger'), match.group('email')
 
     def __str__(self):
@@ -81,7 +83,7 @@ class VersionControl(VersionControlProvider):
     def tag(self, name, message):
         self.runcmd('git', 'tag', '-a', name, '-m', message)
         self.logger.info('Tag {!r} created'.format(name))
-        #http://learn.github.com/p/tagging.html
+        # http://learn.github.com/p/tagging.html
 
         return self
 


### PR DESCRIPTION
Fix PEP8 warnings. 

Only one error remains: 

pytex/versioning/**init**.py:4:1: F403 'from git import *' used; unable to detect undefined names

But I don't see how to fix it. 
